### PR TITLE
[Feature] Implemented media.withAiringSchedule()

### DIFF
--- a/src/connection/airing-schedule-edge.ts
+++ b/src/connection/airing-schedule-edge.ts
@@ -11,7 +11,6 @@ export class AiringScheduleEdge<T = {}> extends Edge<AiringScheduleQuery, IAirin
         super(new AiringScheduleQuery());
     }
 
-    /** @deprecated Always returns null  */
     public withId(): AiringScheduleEdge<T & { id: Required<IAiringScheduleEdge>["id"] }> {
         this.query.set("id", void 0);
         return <never>this;

--- a/src/connection/airing-schedule-edge.ts
+++ b/src/connection/airing-schedule-edge.ts
@@ -1,5 +1,5 @@
-import { AiringScheduleQuery } from "src/queries";
-import type { ExtractAiringSchedule, IAiringScheduleEdge } from "src/typings";
+import { AiringScheduleQuery } from "../queries";
+import type { ExtractAiringSchedule, IAiringScheduleEdge } from "../typings";
 import { Edge } from "./edge";
 
 export interface AiringScheduleEdge<T> {

--- a/src/connection/airing-schedule-edge.ts
+++ b/src/connection/airing-schedule-edge.ts
@@ -1,0 +1,19 @@
+import { AiringScheduleQuery } from "src/queries";
+import type { ExtractAiringSchedule, IAiringScheduleEdge } from "src/typings";
+import { Edge } from "./edge";
+
+export interface AiringScheduleEdge<T> {
+    withNode: <K extends AiringScheduleQuery>(node: K | ((node: AiringScheduleQuery) => K)) => AiringScheduleEdge<T & { node: ExtractAiringSchedule<K> }>;
+}
+
+export class AiringScheduleEdge<T = {}> extends Edge<AiringScheduleQuery, IAiringScheduleEdge> {
+    public constructor() {
+        super(new AiringScheduleQuery());
+    }
+
+    /** @deprecated Always returns null  */
+    public withId(): AiringScheduleEdge<T & { id: Required<IAiringScheduleEdge>["id"] }> {
+        this.query.set("id", void 0);
+        return <never>this;
+    }
+}

--- a/src/connection/index.ts
+++ b/src/connection/index.ts
@@ -1,3 +1,4 @@
+export * from "./airing-schedule-edge";
 export * from "./character-edge";
 export * from "./studio-edge";
 export * from "./staff-edge";

--- a/src/queries/media-query.ts
+++ b/src/queries/media-query.ts
@@ -1,9 +1,11 @@
+import { AiringScheduleQuery } from "./airing-schedule-query";
 import { CharacterQuery } from "./character-query";
 import { StudioQuery } from "./studio-query";
 import { StaffQuery } from "./staff-query";
 import { Base } from "../base";
 
 import {
+    AiringScheduleEdge,
     CharacterEdge,
     StudioEdge,
     MediaEdge,
@@ -12,6 +14,8 @@ import {
 } from "../connection";
 
 import type {
+    ExtractAiringScheduleEdge,
+    ExtractAiringSchedule,
     MediaStreamingEpisode,
     ExtractCharacterEdge,
     MediaExternalLink,
@@ -359,8 +363,32 @@ export class MediaQuery<T = {}> extends Base<Media, MediaArguments> {
         return <never>this;
     }
 
-    //! PENDING!!!
-    // public withAiringSchedule() {}
+    public withAiringSchedule<E extends AiringScheduleEdge, A extends AiringScheduleQuery, P extends PageInfo>(options?: {
+        edges?: E | ((edge: AiringScheduleEdge) => E),
+        nodes?: A | ((node: AiringScheduleQuery) => A),
+        pageInfo?: P | ((page: PageInfo) => P),
+        args?: {
+            notYetAired?: boolean,
+            page?: number,
+            perPage?: number
+        }
+    }): MediaQuery<T & { airingSchedule: Expand<MapRelations<ExtractAiringScheduleEdge<E>, ExtractAiringSchedule<A>, ExtractPageInfo<P>>> }> {
+        if (!options) {
+            this.query.set("airingSchedule", ["nodes { id, airingAt, episode }"]);
+            return <never>this;
+        }
+        const arr: Array<string> = [];
+        const edges = typeof options.edges === "function" ? options.edges(new AiringScheduleEdge()).parse() : options.edges?.parse();
+        const nodes = typeof options.nodes === "function" ? options.nodes(new AiringScheduleQuery()).parse() : options.nodes?.parse();
+        const pageInfo = typeof options.pageInfo === "function" ? options.pageInfo(new PageInfo()).parse() : options.pageInfo?.parse();
+
+        edges && arr.push(`edges { ${edges.fields} }`);
+        nodes && arr.push(`nodes { ${nodes.fields} }`);
+        pageInfo && arr.push(`pageInfo { ${pageInfo.fields} }`);
+
+        this.query.set("airingSchedule", { args: options.args, fields: arr.length ? arr : ["nodes { id, airingAt, episode }"] });
+        return <never>this;
+    }
     //! PENDING!!!
     // public withTrends() {}
 

--- a/src/queries/page-query.ts
+++ b/src/queries/page-query.ts
@@ -16,7 +16,7 @@ import type {
     PageArguments,
     ExtractMedia,
     ExtractStaff,
-    Page,
+    Page
 } from "../typings";
 import { MediaTrendQuery } from "./media-trend-query";
 

--- a/src/typings/airing/airing-schedule-connection.ts
+++ b/src/typings/airing/airing-schedule-connection.ts
@@ -1,4 +1,4 @@
-import type { AiringSchedule, AiringScheduleEdge } from ".";
+import type { AiringSchedule, IAiringScheduleEdge } from ".";
 import type { Connection } from "../connection";
 
-export interface AiringScheduleConnection extends Connection<AiringScheduleEdge, AiringSchedule> { }
+export interface AiringScheduleConnection extends Connection<IAiringScheduleEdge, AiringSchedule> { }

--- a/src/typings/airing/airing-schedule-edge.ts
+++ b/src/typings/airing/airing-schedule-edge.ts
@@ -1,6 +1,6 @@
 import type { AiringSchedule } from "./airing-schedule";
 import type { IEdge } from "../edge";
 
-export interface AiringScheduleEdge extends IEdge<AiringSchedule> {
+export interface IAiringScheduleEdge extends IEdge<AiringSchedule> {
     id?: number | null;
 }

--- a/src/typings/extract/extract-airing-schedule-edge.ts
+++ b/src/typings/extract/extract-airing-schedule-edge.ts
@@ -1,0 +1,3 @@
+import type { AiringScheduleEdge } from "src/connection/airing-schedule-edge";
+
+export type ExtractAiringScheduleEdge<T> = T extends AiringScheduleEdge<infer S> ? { [K in keyof S]: S[K] } : never;

--- a/src/typings/extract/extract-airing-schedule-edge.ts
+++ b/src/typings/extract/extract-airing-schedule-edge.ts
@@ -1,3 +1,3 @@
-import type { AiringScheduleEdge } from "src/connection/airing-schedule-edge";
+import type { AiringScheduleEdge } from "../../connection/airing-schedule-edge";
 
 export type ExtractAiringScheduleEdge<T> = T extends AiringScheduleEdge<infer S> ? { [K in keyof S]: S[K] } : never;

--- a/src/typings/extract/index.ts
+++ b/src/typings/extract/index.ts
@@ -1,3 +1,4 @@
+export type * from "./extract-airing-schedule-edge";
 export type * from "./extract-airing-schedule";
 export type * from "./extract-character-edge";
 export type * from "./extract-studio-edge";


### PR DESCRIPTION
Implementation of `MediaQuery.withAiringSchedule()` [[media-query.ts#L363](https://github.com/Didas-git/anilist-wrapper/blob/e38e9e8fab8959af84ebd46647ee15e17d25b4b0/src/queries/media-query.ts#L363)]

<details>
<summary>Example usage</summary>

```ts
const queryWithAiringSchedule = anilist.query
	.media({
		type: "ANIME",
		idMal: 55644,
	})
	.withMalId()
	.withId()
	.withStatus()
	.withTitles("english", "romaji", "native", "userPreferred")
	.withAiringSchedule({
		edges: (edge) =>
			edge
				.withId()
				.withNode((node) =>
					node
						.withId()
						.withEpisode()
						.airingAt()
						.timeUntilAiring()
						.withMediaId()
				),
		nodes: (node) =>
			node
				.withId()
				.withEpisode()
				.airingAt()
				.timeUntilAiring()
				.withMediaId(),
	});

```

</details>


# Opinionated Changes:

- Marked `AiringScheduleEdge.withId()` as deprecated because the API only returns null on this field (At least in my tests) [[Anilist API Playground](https://anilist.co/graphiql?query=%7B%0A%20%20Media(idMal%3A%2055644%2C%20type%3AANIME)%7B%0A%20%20%20%20id%2C%0A%20%20%20%20idMal%2C%0A%20%20%20%20title%7B%0A%20%20%20%20%20%20romaji%2C%0A%20%20%20%20%20%20english%2C%0A%20%20%20%20%20%20native%2C%0A%20%20%20%20%20%20userPreferred%0A%20%20%20%20%7D%2C%0A%20%20%20%20airingSchedule%7B%0A%20%20%20%20%20%20edges%7B%0A%20%20%20%20%20%20%20%20id%2C%0A%20%20%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20%20%20id%2C%0A%20%20%20%20%20%20%20%20%20%20airingAt%2C%0A%20%20%20%20%20%20%20%20%20%20timeUntilAiring%2C%0A%20%20%20%20%20%20%20%20%20%20episode%2C%0A%20%20%20%20%20%20%20%20%20%20mediaId%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20nodes%7B%0A%20%20%20%20%20%20%20%20id%2C%0A%20%20%20%20%20%20%20%20airingAt%2C%0A%20%20%20%20%20%20%20%20timeUntilAiring%2C%0A%20%20%20%20%20%20%20%20episode%2C%0A%20%20%20%20%20%20%20%20mediaId%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A)]

- Renamed `src/typings/airing/airing-schedule-edge.ts:` `AiringScheduleEdge` to `IAiringScheduleEdge` to match the projects naming conventions and avoid conflicts with `src/connection/airing-schedule-edge.ts`


# Testing Environment

- NextJS 14.0.3 (`next dev` without --turbo)


# Suggestions

These changes are not included as they do not provide an actual advantage

- rename `AiringScheduleQuery.airingAt()` to `AiringScheduleQuery.withAiringAt()`

- rename `AiringScheduleQuery.timeUntilAiring()` to `AiringScheduleQuery.withTimeUntilAiring()`
